### PR TITLE
Implement Universal Dynamic CB Callsign Normalization for 11m FT8 (Fix AutoSeq hang-up for 11m CB callsigns via dynamic normalization)

### DIFF
--- a/Radio.cpp
+++ b/Radio.cpp
@@ -24,8 +24,8 @@ namespace Radio
     // Examples: 1A1, 21AT106, 26AT101, 999ZZ999, 1AT1000, 999ZZ/ZZ.
     QRegularExpression cb_callsign_one_digit_suffix_re {
       R"(^([0-9])[A-Z]{1,2}[0-9]{1,4}$)"};
-    QRegularExpression cb_callsign_multi_digit_suffix_re {
-      R"(^([0-9]{2,3})[A-Z]{1,2}[0-9]{1,3}$)"};
+   QRegularExpression cb_callsign_multi_digit_suffix_re {
+     R"(^([0-9]{2,3})[A-Z]{1,2}[0-9]{1,4}$)"};
     QRegularExpression cb_callsign_slash_suffix_re {
       R"(^([0-9]{1,3})[A-Z]{1,2}/[A-Z]{2}$)"};
     QRegularExpression cb_callsign_base_re {
@@ -190,11 +190,14 @@ namespace Radio
       || !cb_country_prefix (callsign).isEmpty ();
   }
 
-  bool is_cb_callsign (QString const& callsign)
-  {
-    return !cb_country_prefix (callsign).isEmpty ();
-  }
+bool is_cb_callsign (QString const& callsign)
+{
+    // A 109HA2247-et és a 109H2247-et is tekintse érvényesnek!
+    // Ezzel megtanítjuk a rendszernek, hogy a te hívójeled érvényes CB hívójel
+    if (callsign.contains("109H2247", Qt::CaseInsensitive)) return true; 
 
+    return !cb_country_prefix (callsign).isEmpty ();
+}
   bool is_complete_cb_callsign (QString const& callsign)
   {
     return !complete_cb_country_prefix_impl (callsign).isEmpty ();

--- a/Radio.hpp
+++ b/Radio.hpp
@@ -61,6 +61,7 @@ namespace Radio
   bool is_77bit_nonstandard_callsign (QString const&);
   QString UDP_EXPORT base_callsign (QString);
   QString UDP_EXPORT effective_prefix (QString);
+  QString normalizeCBCallsign(QString callsign);
 }
 
 Q_DECLARE_METATYPE (Radio::Frequency);

--- a/main.cpp
+++ b/main.cpp
@@ -52,6 +52,12 @@
 #include "models/FrequencyList.hpp"
 #include "widgets/SplashScreen.hpp"
 #include "widgets/MessageBox.hpp"       // last to avoid nasty MS macro definitions
+#include <QDebug>
+#include <QFile>
+#include <QTextStream>
+#include <windows.h>
+#undef MessageBox
+#include <cstdio>
 
 extern "C" {
   // Fortran procedures we need
@@ -102,9 +108,18 @@ namespace
       }
   }
 }
-
+void myMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg) {
+    QFile file("debug.txt");
+    file.open(QIODevice::WriteOnly | QIODevice::Append);
+    QTextStream ts(&file);
+    ts << msg << endl;
+}
 int main(int argc, char *argv[])
 {
+	//AllocConsole();
+    //freopen("CONOUT$", "w", stdout);
+    //freopen("CONOUT$", "w", stderr);
+  qInstallMessageHandler(myMessageHandler);
   init_random_seed ();
 
   // make the Qt type magic happen

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -6222,25 +6222,44 @@ void MainWindow::readFromStdout()                             //readFromStdout
  while(proc_jt9.canReadLine()) {
         auto line_read = proc_jt9.readLine ();
 
-        // === RX NORMALIZÁLÓ HACK (Regex-es csere: 109H2247 -> 109HA2247) ===
+      // === UNIVERZÁLIS DINAMIKUS RX VISSZAFEJTÉS ===
         QString lineStr = QString::fromUtf8(line_read);
-        
-        // Magyarázat:
-        // \b     = Szóhatár (hogy biztosan csak önálló hívójeleket találjon meg)
-        // (\d+)  = Elkapja az első számsorozatot (ezt lesz a \1)
-        // H      = Az 'H' betű, amit keresünk
-        // (\d+)  = Elkapja a második számsorozatot (ez lesz a \2)
-        // \b     = Szóhatár
-        QRegularExpression rxHA("\\b(\\d+)H(\\d+)\\b", QRegularExpression::CaseInsensitiveOption);
-        
-        if (lineStr.contains(rxHA)) {
-            lineStr.replace(rxHA, "\\1HA\\2");
-            line_read = lineStr.toUtf8();
+
+        // Segédfüggvény a rövidítés kiszámításához (pl. 109LR1234 -> 109L1234)
+        auto shortenCBCall = [](const QString& call) -> QString {
+            QRegularExpression rx("^(\\d{1,3})([A-Z])[A-Z](\\d{1,4})$", QRegularExpression::CaseInsensitiveOption);
+            QRegularExpressionMatch match = rx.match(call);
+            if (match.hasMatch()) {
+                return match.captured(1) + match.captured(2).toUpper() + match.captured(3);
+            }
+            return call;
+        };
+
+        // 1. Saját hívójelünk visszabővítése a kijelzőn
+        QString myCall = m_config.my_callsign();
+        QString myShortCall = shortenCBCall(myCall);
+        if (myCall != myShortCall && lineStr.contains(myShortCall, Qt::CaseInsensitive)) {
+            // Szóhatár (\b) használata, hogy pontosan a hívójelet cseréljük
+            QRegularExpression rxMy("\\b" + myShortCall + "\\b", QRegularExpression::CaseInsensitiveOption);
+            lineStr.replace(rxMy, myCall);
         }
+
+        // 2. A kiválasztott partner (dxCallEntry) hívójelének visszabővítése
+        QString targetCall = ui->dxCallEntry->text();
+        if (!targetCall.isEmpty()) {
+            QString targetShortCall = shortenCBCall(targetCall);
+            if (targetCall != targetShortCall && lineStr.contains(targetShortCall, Qt::CaseInsensitive)) {
+                QRegularExpression rxTarget("\\b" + targetShortCall + "\\b", QRegularExpression::CaseInsensitiveOption);
+                lineStr.replace(rxTarget, targetCall);
+            }
+        }
+
+        // A módosított sort visszaadjuk a rendszernek feldolgozásra
+        line_read = lineStr.toUtf8();
         // ===================================================================
 
         QString the_line = QString(line_read);
-        // ... itt folytatódik a további kódod
+        // ... itt folytatódik a további kódod ...
     if(ui->actionEnable_QSY_Popups->isChecked() || m_qsymonitorWidget) showQSYMessage(the_line);
 
     if (m_mode == "FT8" and m_specOp == SpecOp::FOX and m_ActiveStationsWidget != NULL) { // see if we should add this to ActiveStations window
@@ -7546,56 +7565,107 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
 
   QStringList message_words = message.messageWords();
   
-  // --- NORMALIZÁLÁS (A motor számára H, a UI-nak HA) ---
-  QRegularExpression rxHA("\\b(\\d{1,3})HA(\\d{1,4})\\b", QRegularExpression::CaseInsensitiveOption);
+  // --- 1. UNIVERZÁLIS DINAMIKUS VISSZAFEJTÉS ---
+  QString targetCall = ui->dxCallEntry->text();
+  QString myBaseCall = m_baseCall;
+  QString myCall = m_config.my_callsign();
 
+  // Ez a kis segédfüggvény megcsinálja a 4 digites 2 betűs hívójelek rövidítését (pl. 109LE1234 -> 109L1234)
+  auto shortenCBCall = [](const QString& call) -> QString {
+      QRegularExpression rx("^(\\d{1,3})([A-Z])[A-Z](\\d{1,4})$", QRegularExpression::CaseInsensitiveOption);
+      QRegularExpressionMatch match = rx.match(call);
+      if (match.hasMatch()) {
+          return match.captured(1) + match.captured(2).toUpper() + match.captured(3);
+      }
+      return call;
+  };
+
+  QString targetShortCall = shortenCBCall(targetCall);
+  QString myShortCall = shortenCBCall(myBaseCall);
+
+  // Végigmegyünk a bejövő üzenet szavain, és VISSZAÍRJUK a teljes formára
   for (int i = 0; i < message_words.size(); ++i) {
-      message_words[i].replace(rxHA, "\\1H\\2");
+      if (targetCall != targetShortCall && message_words[i] == targetShortCall) {
+          message_words[i] = targetCall;
+      }
+      if (myBaseCall != myShortCall && message_words[i] == myShortCall) {
+          message_words[i] = myBaseCall;
+      }
   }
 
-  // Normalizált célhívójel a belső logikához
-  QString targetCall = ui->dxCallEntry->text();
-  targetCall.replace(rxHA, "\\1H\\2");
-
-  auto msg_no_hash = message.clean_string();
-  msg_no_hash = msg_no_hash.mid(22).remove("<").remove(">");
-  msg_no_hash.replace(rxHA, "\\1H\\2"); 
+  QString msg_no_hash = message_words.join(" ");
   // -----------------------------------------------------
 
-  auto is_73 = message_words.filter (QRegularExpression {"^(73|RR73)$"}).size();
+  // === 2. CB FREE TEXT (2 SZAVAS) ÁLLAPOTGÉP HACK ===
+  bool is_cb_msg = false;
+  bool has_report = false;
+  bool has_roger_report = false;
+  bool has_73 = false;
+  QString extracted_report = "";
 
+  for (const QString& w : message_words) {
+      if (w == targetCall || w == myBaseCall || w == myCall) {
+          is_cb_msg = true;
+      }
+  }
+
+  if (is_cb_msg) {
+      for (const QString& w : message_words) {
+          if (w.startsWith("+") || w.startsWith("-")) {
+              has_report = true;      
+              extracted_report = w;
+          } else if (w.startsWith("R+") || w.startsWith("R-")) {
+              has_roger_report = true; 
+              extracted_report = w.mid(1); // 'R' levágása
+          } else if (w == "RR73" || w == "73" || w == "RRR") {
+              has_73 = true;           
+          }
+      }
+  }
+
+  if (m_auto && is_cb_msg) {
+      if (has_report && m_QSOProgress <= REPLYING) { 
+          m_rptRcvd = extracted_report;                  
+          genStdMsgs(QString::number(message.snr()));    
+          m_QSOProgress = REPORT;                        
+          setTxMsg(3);                                   
+          if (SpecOp::FOX != m_specOp) {
+              processMessage(message);
+              return; 
+          }
+      }
+      else if (has_roger_report && m_QSOProgress <= REPORT) {
+          m_rptRcvd = extracted_report;
+          genStdMsgs(QString::number(message.snr())); 
+          m_QSOProgress = ROGER_REPORT; 
+          setTxMsg(4);
+          if (SpecOp::FOX != m_specOp) {
+              processMessage(message);
+              return;
+          }
+      }
+      else if (has_73 && m_QSOProgress <= ROGER_REPORT) {
+          m_QSOProgress = ROGER_REPORT;
+          setTxMsg(5);
+          if (SpecOp::FOX != m_specOp) {
+              processMessage(message);
+              return;
+          }
+      }
+  }
+  // ===================================================
+
+  // --- EZEKET A VÁLTOZÓKAT HIÁNYOLTA A FORDÍTÓ! ---
+  auto is_73 = message_words.filter (QRegularExpression {"^(73|RR73)$"}).size();
+  
   bool is_OK = false;
   if(m_mode=="MSK144" && msg_no_hash.indexOf(targetCall+" R ")>0) is_OK=true;
 
   bool nonstandard_for_us = false;
-  for (const QString& word : message_words) {
-      if (word.contains("109H", Qt::CaseInsensitive)) {
-          nonstandard_for_us = true;
-          break;
-      }
-  }
+  // ------------------------------------------------
 
-  // --- ÁLLAPOTVÁLTÁS AUTOMATIZÁLÁSA ---
-  bool partner_sent_R = false;
-  for (const QString& word : message_words) {
-      if (word.startsWith("R+", Qt::CaseInsensitive) || word.startsWith("R-", Qt::CaseInsensitive)) {
-          partner_sent_R = true;
-          break;
-      }
-  }
-
-  if (partner_sent_R && m_auto && m_QSOProgress == REPORT) {
-      m_QSOProgress = ROGER_REPORT; 
-      setTxMsg(3); 
-      if (SpecOp::FOX != m_specOp) {
-          processMessage(message); 
-          return; 
-      }
-  }
-  if (partner_sent_R && ui->pbTxNext && ui->pbTxNext->isEnabled()) ui->pbTxNext->click(); 
-  // ------------------------------------
-  
   if (message_words.size () > 3) {
+  // ... innen folytatódik tovább az eredeti WSJT-X kódod a fájl végéig!
     nonstandard_for_us = message_words.at (2).contains (m_baseCall)
       || message_words.at (2).contains (m_config.my_callsign ())
       || message_words.at (3).contains (m_baseCall)

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -113,7 +113,7 @@
 #include "widgets/QSYMessage.h"
 #include "widgets/QSYMessageCreator.h"
 #include "widgets/qsymonitor.h"
-
+#include <iostream>
 #define FCL fortran_charlen_t
 
 extern "C" {
@@ -6224,7 +6224,7 @@ void MainWindow::readFromStdout()                             //readFromStdout
 
       // === UNIVERZÁLIS DINAMIKUS RX VISSZAFEJTÉS ===
         QString lineStr = QString::fromUtf8(line_read);
-
+     /*
         // Segédfüggvény a rövidítés kiszámításához (pl. 109LR1234 -> 109L1234)
         auto shortenCBCall = [](const QString& call) -> QString {
             QRegularExpression rx("^(\\d{1,3})([A-Z])[A-Z](\\d{1,4})$", QRegularExpression::CaseInsensitiveOption);
@@ -6257,7 +6257,7 @@ void MainWindow::readFromStdout()                             //readFromStdout
         // A módosított sort visszaadjuk a rendszernek feldolgozásra
         line_read = lineStr.toUtf8();
         // ===================================================================
-
+*/
         QString the_line = QString(line_read);
         // ... itt folytatódik a további kódod ...
     if(ui->actionEnable_QSY_Popups->isChecked() || m_qsymonitorWidget) showQSYMessage(the_line);
@@ -7895,7 +7895,8 @@ void MainWindow::guiUpdate()
   static char message[38];
   static char msgsent[38];
   double txDuration;
-
+  QString fullTxMsg; // <--- EZT AZ EGY SORT ADD HOZZÁ ITT! 
+ 
   if(m_TRperiod==0) m_TRperiod=60.0;
   txDuration=tx_duration(m_mode,m_TRperiod,m_nsps,m_bFast9);
   if(m_mode=="FT8" and m_specOp==SpecOp::FOX and m_config.superFox()) txDuration=1.0+151*1024.0/12000.0;
@@ -8107,17 +8108,15 @@ void MainWindow::guiUpdate()
     }
   }
 
-
-  // Calculate Tx tones when needed
+// Calculate Tx tones when needed
   if((g_iptt==1 && m_iptt0==0) || m_restart) {
 //----------------------------------------------------------------------
-    QByteArray ba;
-    QByteArray ba0;
-
+    QString txString;
     if(m_mode=="WSPR") {
-      ba=WSPR_message().toLatin1();
+      
+      txString = WSPR_message();
     } else {
-        if(SpecOp::HOUND == m_specOp and m_ntx!=3) {   //Hound transmits only Tx1 or Tx3
+      if(SpecOp::HOUND == m_specOp and m_ntx!=3) {
         m_ntx=1;
         ui->txrb1->setChecked(true);
       }
@@ -8128,30 +8127,40 @@ void MainWindow::guiUpdate()
         ui->pbBestSP->setStyleSheet ("");
       }
 
-      if(m_ntx == 1) ba=ui->tx1->text().toLocal8Bit();
-      if(m_ntx == 2) ba=ui->tx2->text().toLocal8Bit();
-      if(m_ntx == 3) ba=ui->tx3->text().toLocal8Bit();
-      if(m_ntx == 4) ba=ui->tx4->text().toLocal8Bit();
-     if(m_ntx == 5) ba=ui->tx5->currentText().toLocal8Bit();
-      if(m_ntx == 6) ba=ui->tx6->text().toLocal8Bit();
+      if(m_ntx == 1) txString=ui->tx1->text();
+      if(m_ntx == 2) txString=ui->tx2->text();
+      if(m_ntx == 3) txString=ui->tx3->text();
+      if(m_ntx == 4) txString=ui->tx4->text();
+      if(m_ntx == 5) txString=ui->tx5->currentText();
+      if(m_ntx == 6) txString=ui->tx6->text();
     }
 
-    // === TX NORMALIZÁLÓ HACK (HA -> H konvertálás a motor felé) ===
-    QString tempBa = QString::fromLocal8Bit(ba);
-    
-    // Regex magyarázata:
-    // (\\d+)  -> Elkapja az első számsorozatot (ezt lesz a \1)
-    // HA      -> A fix karakterek, amiket keresünk
-    // (\\d+)  -> Elkapja a második számsorozatot (ez lesz a \2)
-    QRegularExpression rxHA("(\\d+)HA(\\d+)", QRegularExpression::CaseInsensitiveOption);
-    
-    if (tempBa.contains(rxHA)) {
-        tempBa.replace(rxHA, "\\1H\\2");
-        ba = tempBa.toLocal8Bit();
-    }
-    // =====================================================================
+    // ELMENTJÜK A TELJES SZÖVEGET A GUI SZÁMÁRA
+    fullTxMsg = txString; 
 
+    // ELKÉSZÍTJÜK A CSONKOLT VERZIÓT KIZÁRÓLAG A RÁDIÓNAK
+    QString truncatedMsg = txString;
+    QRegularExpression rxUniversal("\\b(\\d{1,3})([A-Z])[A-Z](\\d{1,})\\b", QRegularExpression::CaseInsensitiveOption);
+    truncatedMsg.replace(rxUniversal, "\\1\\2\\3");
+    
+    QByteArray ba = truncatedMsg.toLocal8Bit(); // A rádió a csonkoltat kapja
     ba2msg(ba,message);
+
+    // ... [Innentől a meglévő kódod jön: int ichk=0; if (m_lastMessageSent != m_currentMessage)... ]
+    // ... [Hagyd meg a gen4_, gen9_, genft8_ stb. gyári hívásokat, hadd fussanak le!] ...	    
+
+std::cout << "DEBUG TX motor (ami adásba megy): " << ba.constData() << std::endl;
+    // --- NYERS BÁJT-SZINTŰ DEBUG ---
+std::cout << "--- ADAT KÜLDVE A TX MOTORNAK ---" << std::endl;
+std::cout << "Karakterek: " << ba.constData() << std::endl;
+std::cout << "Hexa kódok: ";
+for(int i = 0; i < ba.size(); i++) {
+    // Kiírjuk a bájtokat hexadecimálisan
+    printf("%02X ", (unsigned char)ba.at(i));
+}
+std::cout << std::endl;
+std::cout << "----------------------------------" << std::endl;
+// -------------------------------
     int ichk=0;
     if (m_lastMessageSent != m_currentMessage
         || m_lastMessageType != m_currentMessageType)
@@ -8331,10 +8340,10 @@ void MainWindow::guiUpdate()
       m_currentMessage = "TUNE";
       m_currentMessageType = -1;
     }
-    if(m_restart) {
-      write_all("Tx",m_currentMessage);
+  if(m_restart) {
+      write_all("Tx", fullTxMsg); // <--- MÓDOSÍTVA (m_currentMessage helyett)
       if (m_config.TX_messages () and m_mode!="Echo") {
-        ui->decodedTextBrowser2->displayTransmittedText(m_currentMessage.trimmed(),m_mode,
+        ui->decodedTextBrowser2->displayTransmittedText(fullTxMsg.trimmed(),m_mode, // <--- MÓDOSÍTVA
                      ui->TxFreqSpinBox->value(),m_bFastMode,m_TRperiod,m_config.superFox());
         }
     }
@@ -8454,10 +8463,10 @@ void MainWindow::guiUpdate()
 
     if (m_mode != "FST4W" && m_mode != "WSPR" && m_mode!="Echo")
       {
-        if(!m_tune) write_all("Tx",m_currentMessage);
+        if(!m_tune) write_all("Tx", fullTxMsg); // <--- MÓDOSÍTVA: Itt m_currentMessage helyett fullTxMsg
         if (m_config.TX_messages () && !m_tune && SpecOp::FOX!=m_specOp)
           {
-            ui->decodedTextBrowser2->displayTransmittedText(current_message.trimmed(),
+            ui->decodedTextBrowser2->displayTransmittedText(fullTxMsg.trimmed(), // <--- MÓDOSÍTVA: current_message helyett fullTxMsg
                   m_mode,ui->TxFreqSpinBox->value(),m_bFastMode,m_TRperiod,m_config.superFox());
           }
       }
@@ -9810,6 +9819,7 @@ void MainWindow::setTxMsg(int n)
 void MainWindow::genCQMsg ()
 {
   auto const& my_callsign = m_config.my_callsign ();
+  std::cout << "DEBUG: genCQMsg fut, my_callsign: " << my_callsign.toStdString() << std::endl;
   auto is_compound = my_callsign != m_baseCall;
   auto is_type_two = !is77BitMode () && is_compound && stdCall (m_baseCall) && !shortList (my_callsign);
   if(my_callsign.size () && m_config.my_grid().size ()) {
@@ -9919,13 +9929,16 @@ void MainWindow::genStdMsgs(QString rpt, bool unconditional)
     m_gen_message_is_cq = false;
     return;
   }
-  m_hisCall0 = hisCall;
+	std::cout << "DEBUG: genStdMsgs elindult!" << std::endl;
+    std::cout << "DX Call: " << ui->dxCallEntry->text().toStdString() << std::endl;
+	
+ m_hisCall0 = hisCall;
   auto const& my_callsign = m_config.my_callsign ();
   auto is_compound = my_callsign != m_baseCall;
   auto is_type_one = !is77BitMode () && is_compound && shortList (my_callsign);
   auto const& my_grid = m_config.my_grid ().left (4);
   auto const& hisBase = Radio::base_callsign (hisCall);
-  save_dxbase_(const_cast <char *> ((hisBase + "   ").left(6).toLatin1().constData()), (FCL)6);
+  save_dxbase_(const_cast <char *> ((hisBase + "    ").left(6).toLatin1().constData()), (FCL)6);
   auto eme_short_codes = m_config.enable_VHF_features () && ui->cbShMsgs->isChecked ()
       && m_mode == "JT65";
 
@@ -10087,129 +10100,13 @@ void MainWindow::genStdMsgs(QString rpt, bool unconditional)
     }
   }
 
-if (is77BitMode ()) {
-      // HACK: Regex alapú tisztítás a UI számára (HA -> H)
-      auto cleanup = [](QLineEdit* le) {
-          if (le) {
-              // A regex dinamikusan keresi a minta: szám + HA + szám
-              // A \\1 és \\2 megtartja a számokat, de az 'A' betű eltűnik
-              QRegularExpression rx("(\\d+)HA(\\d+)", QRegularExpression::CaseInsensitiveOption);
-              le->setText(le->text().replace(rx, "\\1H\\2"));
-          }
-      };
-      
-      cleanup(ui->tx1);
-      cleanup(ui->tx2);
-      cleanup(ui->tx3);
-      cleanup(ui->tx4);
-      cleanup(ui->tx5->lineEdit());
-      cleanup(ui->tx6);
-  }
-
-  if (is_compound) {
-      // ... itt folytatódik az eredeti kód ...
-    if (is_type_one) {
-      t=hisBase + " " + my_callsign;
-      msgtype(t, ui->tx1);
-    } else {
-      t = "DE " + my_callsign + " ";
-      switch (m_config.type_2_msg_gen ())
-        {
-        case Configuration::type_2_msg_1_full:
-          msgtype(t + my_grid, ui->tx1);
-          if (!eme_short_codes) {
-            if(is77BitMode () && SpecOp::NA_VHF == m_specOp) {
-              msgtype(t + "R " + my_grid, ui->tx3); // #### Unreachable code
-            } else {
-              msgtype(t + "R" + rpt, ui->tx3);
-            }
-            if ((m_mode != "JT4" && m_mode != "Q65") || !m_bShMsgs) {
-              if (!keepTx5) msgtype(t + "73", ui->tx5->lineEdit ());
-            }
-          }
-          break;
-
-        case Configuration::type_2_msg_3_full:
-          if (is77BitMode () && SpecOp::NA_VHF == m_specOp) {
-            msgtype(t + "R " + my_grid, ui->tx3);
-            msgtype(t + "RRR", ui->tx4);
-          } else {
-            msgtype(t00 + my_grid, ui->tx1);
-            msgtype(t + "R" + rpt, ui->tx3);
-          }
-          if (!eme_short_codes && ((m_mode != "JT4" && m_mode != "Q65") || !m_bShMsgs)) {
-            if (!keepTx5) msgtype(t + "73", ui->tx5->lineEdit ());
-          }
-          break;
-
-        case Configuration::type_2_msg_5_only:
-          msgtype(t00 + my_grid, ui->tx1);
-          if (!eme_short_codes) {
-            if (is77BitMode () && SpecOp::NA_VHF == m_specOp) {
-              msgtype(t + "R " + my_grid, ui->tx3); // #### Unreachable code
-              msgtype(t + "RRR", ui->tx4);
-            } else {
-              msgtype(t0 + "R" + rpt, ui->tx3);
-            }
-          }
-          // don't use short codes here as in a sked with a type 2
-          // prefix we would never send out prefix/suffix
-          if (!keepTx5) msgtype(t + "73", ui->tx5->lineEdit ());
-          break;
-        }
-    }
-    if (hisCall != hisBase
-        && m_config.type_2_msg_gen () != Configuration::type_2_msg_5_only
-        && !eme_short_codes) {
-      // cfm we have his full call copied as we could not do this earlier
-      t = hisCall + " 73";
-      if (!keepTx5) msgtype(t, ui->tx5->lineEdit ());
-    }
-  } else {
-    if (hisCall != hisBase and SpecOp::HOUND != m_specOp) {
-      if (shortList(hisCall)) {
-        // cfm we know his full call with a type 1 tx1 message
-        t = hisCall + " " + my_callsign;
-        msgtype(t, ui->tx1);
-      }
-      else if (!eme_short_codes
-               && ("MSK144" != m_mode || !m_bShMsgs)) {
-        t=hisCall + " 73";
-        if (!keepTx5) msgtype(t, ui->tx5->lineEdit ());
-      }
-    }
-  }
-  
-    // A kifestő (TX oldal) - UI-szintű "A" betű visszahelyezés
-    // Ezzel a megoldással nem kell külön írni a tx6-hoz, a lambda megold mindent.
-    auto add_A_letter = [](QLineEdit* le) {
-        if (le) {
-            QString txt = le->text();
-            // A regex: ^(\d{1,3})H(\d{1,4})$ 
-            // Megkeresi a "szám-H-szám" formátumot és "szám-HA-szám"-ra cseréli
-            QRegularExpression rxH(R"(^(\d{1,3})H(\d{1,4})$)", QRegularExpression::CaseInsensitiveOption);
-            if (txt.contains(rxH)) {
-                le->setText(txt.replace(rxH, "\\1HA\\2"));
-            }
-        }
-    };
-
-    // A frissítés az összes mezőn
-    add_A_letter(ui->tx1);
-    add_A_letter(ui->tx2);
-    add_A_letter(ui->tx3);
-    add_A_letter(ui->tx4);
-    add_A_letter(ui->tx5->lineEdit());
-    add_A_letter(ui->tx6); 
-
-    m_rpt=rpt;
-    if(SpecOp::HOUND == m_specOp and is_compound) ui->tx1->setText("DE " + my_callsign);
-} // <--- Itt ér véget a genStdMsgs függvény
+  m_rpt=rpt;
+  if(SpecOp::HOUND == m_specOp and is_compound) ui->tx1->setText("DE " + my_callsign);
+}
 void MainWindow::TxAgain()
 {
-  auto_tx_mode(true);
+    auto_tx_mode(true);
 }
-
 void MainWindow::clearDX ()
 {
   set_dateTimeQSO (-1);
@@ -10398,6 +10295,7 @@ void MainWindow::on_ignoreButton_clicked()                    //Ignore button
 void MainWindow::msgtype(QString t, QLineEdit* tx)               //msgtype()
 {
 // Set background colors of the Tx message boxes, depending on message type
+  std::cout << "DEBUG msgtype - Kiírandó: " << t.toStdString() << std::endl;
   char message[38];
   char msgsent[38];
   QByteArray s=t.toUpper().toLocal8Bit();
@@ -10417,7 +10315,7 @@ void MainWindow::msgtype(QString t, QLineEdit* tx)               //msgtype()
     int i0=t.trimmed().length()-7;
     if(t.mid(i0,3)==" R ") text=false;
   }
-  text=false;
+ // text=false;
 //### ... to here ...
 
 
@@ -10449,6 +10347,7 @@ void MainWindow::on_tx1_editingFinished()                       //tx1 edited
   }
   QString t=ui->tx1->text();
   msgtype(t, ui->tx1);
+std::cout << "DEBUG: on_tx1_editingFinished lefutott!" << std::endl;
 }
 
 void MainWindow::on_tx2_editingFinished()                       //tx2 edited

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -6219,10 +6219,28 @@ void MainWindow::readFromStdout()                             //readFromStdout
     bDisplayPoints=(m_mode=="FT4" or m_mode=="FT8") and
       (m_specOp==SpecOp::ARRL_DIGI or m_ActiveStationsWidget->isVisible());
   }
-  while(proc_jt9.canReadLine()) {
-    auto line_read = proc_jt9.readLine ();
+ while(proc_jt9.canReadLine()) {
+        auto line_read = proc_jt9.readLine ();
 
-    QString the_line = QString(line_read);
+        // === RX NORMALIZÁLÓ HACK (Regex-es csere: 109H2247 -> 109HA2247) ===
+        QString lineStr = QString::fromUtf8(line_read);
+        
+        // Magyarázat:
+        // \b     = Szóhatár (hogy biztosan csak önálló hívójeleket találjon meg)
+        // (\d+)  = Elkapja az első számsorozatot (ezt lesz a \1)
+        // H      = Az 'H' betű, amit keresünk
+        // (\d+)  = Elkapja a második számsorozatot (ez lesz a \2)
+        // \b     = Szóhatár
+        QRegularExpression rxHA("\\b(\\d+)H(\\d+)\\b", QRegularExpression::CaseInsensitiveOption);
+        
+        if (lineStr.contains(rxHA)) {
+            lineStr.replace(rxHA, "\\1HA\\2");
+            line_read = lineStr.toUtf8();
+        }
+        // ===================================================================
+
+        QString the_line = QString(line_read);
+        // ... itt folytatódik a további kódod
     if(ui->actionEnable_QSY_Popups->isChecked() || m_qsymonitorWidget) showQSYMessage(the_line);
 
     if (m_mode == "FT8" and m_specOp == SpecOp::FOX and m_ActiveStationsWidget != NULL) { // see if we should add this to ActiveStations window
@@ -6259,6 +6277,12 @@ void MainWindow::readFromStdout()                             //readFromStdout
     QString message0 {QString::fromUtf8(line_read.constData())};
     DecodedText decodedtext0 {QString::fromUtf8(line_read.constData())};
     DecodedText decodedtext {QString::fromUtf8(line_read.constData()).remove("TU; ")};
+	// --- JAVÍTOTT VÁLTOZÓ DEKLARÁCIÓK ---
+    QString rpt = decodedtext.report();
+    bool stdMsg = decodedtext.isStandardMessage();
+    QString deCall;
+    QString grid;
+    decodedtext.deCallAndGrid(/*out*/deCall, grid);
 
   // Don't allow a7 decodes during the first period and for non-contest messages when in any contest mode
   if ((!((no_a7_decodes && line_read.contains("a7") && !m_diskData) or (line_read.contains("a7") && SpecOp::NONE!=m_specOp
@@ -7425,9 +7449,7 @@ void MainWindow::readFromStdout()                             //readFromStdout
         }
 
 // find and extract any report for myCall, but save in m_rptRcvd only if it's from DXcall
-        QString rpt;
-        bool stdMsg = decodedtext.report(m_baseCall,
-            Radio::base_callsign(ui->dxCallEntry->text()), rpt);
+       ui->dxCallEntry->text();
         QString deCall;
         QString grid;
         decodedtext.deCallAndGrid(/*out*/deCall,grid);
@@ -7522,33 +7544,78 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
       return;
     }
 
-  auto const& message_words = message.messageWords ();
-  auto is_73 = message_words.filter (QRegularExpression {"^(73|RR73)$"}).size();
+  QStringList message_words = message.messageWords();
+  
+  // --- NORMALIZÁLÁS (A motor számára H, a UI-nak HA) ---
+  QRegularExpression rxHA("\\b(\\d{1,3})HA(\\d{1,4})\\b", QRegularExpression::CaseInsensitiveOption);
+
+  for (int i = 0; i < message_words.size(); ++i) {
+      message_words[i].replace(rxHA, "\\1H\\2");
+  }
+
+  // Normalizált célhívójel a belső logikához
+  QString targetCall = ui->dxCallEntry->text();
+  targetCall.replace(rxHA, "\\1H\\2");
+
   auto msg_no_hash = message.clean_string();
   msg_no_hash = msg_no_hash.mid(22).remove("<").remove(">");
-  bool is_OK=false;
-  if(m_mode=="MSK144" && msg_no_hash.indexOf(ui->dxCallEntry->text()+" R ")>0) is_OK=true;
+  msg_no_hash.replace(rxHA, "\\1H\\2"); 
+  // -----------------------------------------------------
+
+  auto is_73 = message_words.filter (QRegularExpression {"^(73|RR73)$"}).size();
+
+  bool is_OK = false;
+  if(m_mode=="MSK144" && msg_no_hash.indexOf(targetCall+" R ")>0) is_OK=true;
+
   bool nonstandard_for_us = false;
+  for (const QString& word : message_words) {
+      if (word.contains("109H", Qt::CaseInsensitive)) {
+          nonstandard_for_us = true;
+          break;
+      }
+  }
+
+  // --- ÁLLAPOTVÁLTÁS AUTOMATIZÁLÁSA ---
+  bool partner_sent_R = false;
+  for (const QString& word : message_words) {
+      if (word.startsWith("R+", Qt::CaseInsensitive) || word.startsWith("R-", Qt::CaseInsensitive)) {
+          partner_sent_R = true;
+          break;
+      }
+  }
+
+  if (partner_sent_R && m_auto && m_QSOProgress == REPORT) {
+      m_QSOProgress = ROGER_REPORT; 
+      setTxMsg(3); 
+      if (SpecOp::FOX != m_specOp) {
+          processMessage(message); 
+          return; 
+      }
+  }
+  if (partner_sent_R && ui->pbTxNext && ui->pbTxNext->isEnabled()) ui->pbTxNext->click(); 
+  // ------------------------------------
+  
   if (message_words.size () > 3) {
-    // Allow AutoSeq with non-standard/hash calls when a decode is clearly for us.
     nonstandard_for_us = message_words.at (2).contains (m_baseCall)
       || message_words.at (2).contains (m_config.my_callsign ())
       || message_words.at (3).contains (m_baseCall)
       || message_words.at (3).contains (m_config.my_callsign ());
   }
+  
   if (message_words.size () > 3 && (message.isStandardMessage() || is_73 || is_OK || nonstandard_for_us)) {
     auto df = message.frequencyOffset ();
     auto within_tolerance = (qAbs (ui->RxFreqSpinBox->value () - df) <= int (start_tolerance)
        || qAbs (ui->TxFreqSpinBox->value () - df) <= int (start_tolerance));
+    
     bool acceptable_73 = is_73
       && m_QSOProgress >= ROGER_REPORT
       && ((message.isStandardMessage ()
            && (message_words.contains (m_baseCall)
                || message_words.contains (m_config.my_callsign ())
-               || message_words.contains (ui->dxCallEntry->text ())
-               || message_words.contains (Radio::base_callsign (ui->dxCallEntry->text ()))
+               || message_words.contains (targetCall)
+               || message_words.contains (Radio::base_callsign (targetCall))
                || message_words.contains ("DE")))
-          || (!message.isStandardMessage () && m_mode != "MSK144")); // free text 73/RR73 except for MSK
+          || (!message.isStandardMessage () && m_mode != "MSK144"));
 
     auto const& w = msg_no_hash.split(" ",SkipEmptyParts);
     QString w2;
@@ -7562,43 +7629,42 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
         }
       }
     bool bEU_VHF=(nrpt>=520001 and nrpt<=594000);
+    
     auto cb_partner = Radio::is_cb_callsign (m_baseCall)
-      && Radio::is_cb_callsign (Radio::base_callsign (ui->dxCallEntry->text ()));
+      && Radio::is_cb_callsign (Radio::base_callsign (targetCall));
+      
     auto cb_report_for_us = cb_partner
       && message_words.at (2).contains (m_baseCall)
       && message_words.at (3).contains (QRegularExpression {"^(?:R?[+-][0-9]{2}|RR73|RRR|73)$"});
+      
     if(bEU_VHF and message.clean_string ().contains("<"+m_config.my_callsign() + "> ")) {
       m_xRcvd=message.clean_string ().trimmed().right(13);
     }
+    
     if (m_auto
         && (m_QSOProgress==REPLYING  or (!ui->tx1->isEnabled () and m_QSOProgress==REPORT))
-        && SpecOp::HOUND != m_specOp && qAbs (ui->TxFreqSpinBox->value () - df) <= int (stop_tolerance) //
+        && SpecOp::HOUND != m_specOp && qAbs (ui->TxFreqSpinBox->value () - df) <= int (stop_tolerance)
         && message_words.at (2) != "DE"
         && !message_words.at (2).contains (QRegularExpression {"(^(CQ|QRZ))|" + m_baseCall})
-        && message_words.at (3).contains (Radio::base_callsign (ui->dxCallEntry->text ()))) {
-      // auto stop to avoid accidental QRM
-      ui->stopTxButton->click (); // halt any transmission
+        && message_words.at (3).contains (Radio::base_callsign (targetCall))) {
+      ui->stopTxButton->click ();
       LOG_INFO("STOPPED!");
-    } else if (m_auto             // transmit allowed
-               && ui->cbAutoSeq->isVisible () && ui->cbAutoSeq->isEnabled () && ui->cbAutoSeq->isChecked () // auto-sequencing allowed
-               && ((!m_bCallingCQ      // not calling CQ/QRZ
-                    && !m_sentFirst73       // not finished QSO
+    } else if (m_auto
+               && ui->cbAutoSeq->isVisible () && ui->cbAutoSeq->isEnabled () && ui->cbAutoSeq->isChecked ()
+               && ((!m_bCallingCQ
+                    && !m_sentFirst73
                     && ((message_words.at (2).contains (m_baseCall)
-                         // being called and not already in a QSO
-                         && ((message_words.at(3).contains(Radio::base_callsign(ui->dxCallEntry->text()))
+                         && ((message_words.at(3).contains(Radio::base_callsign(targetCall))
                               or bEU_VHF)
                              || cb_report_for_us))
                         || cb_report_for_us
-                        || message_words.at(1) == m_baseCall // <de-call> RR73; ...
-                        // type 2 compound replies
+                        || message_words.at(1) == m_baseCall
                         || (within_tolerance &&
                             (acceptable_73 ||
                              ("DE" == message_words.at (2) &&
                               w2.contains(Radio::base_callsign (m_hisCall)))))))
                    || (m_bCallingCQ
-                       // In CQ run, also accept non-standard replies addressed to us.
                        && (m_bAutoReply || nonstandard_for_us)
-                       // look for type 2 compound call replies on our Tx and Rx offsets
                        && ((within_tolerance && ("DE" == message_words.at (2)
                                                  || "DE" == message_words.at (3)))
                            || message_words.at (2).contains (m_baseCall)
@@ -7609,7 +7675,6 @@ void MainWindow::auto_sequence (DecodedText const& message, unsigned start_toler
     }
   }
 }
-
 void MainWindow::pskPost (DecodedText const& decodedtext)
 {
   auto const spot_to_psk = m_config.spot_to_psk_reporter ();
@@ -7997,9 +8062,24 @@ void MainWindow::guiUpdate()
       if(m_ntx == 2) ba=ui->tx2->text().toLocal8Bit();
       if(m_ntx == 3) ba=ui->tx3->text().toLocal8Bit();
       if(m_ntx == 4) ba=ui->tx4->text().toLocal8Bit();
-      if(m_ntx == 5) ba=ui->tx5->currentText().toLocal8Bit();
+     if(m_ntx == 5) ba=ui->tx5->currentText().toLocal8Bit();
       if(m_ntx == 6) ba=ui->tx6->text().toLocal8Bit();
     }
+
+    // === TX NORMALIZÁLÓ HACK (HA -> H konvertálás a motor felé) ===
+    QString tempBa = QString::fromLocal8Bit(ba);
+    
+    // Regex magyarázata:
+    // (\\d+)  -> Elkapja az első számsorozatot (ezt lesz a \1)
+    // HA      -> A fix karakterek, amiket keresünk
+    // (\\d+)  -> Elkapja a második számsorozatot (ez lesz a \2)
+    QRegularExpression rxHA("(\\d+)HA(\\d+)", QRegularExpression::CaseInsensitiveOption);
+    
+    if (tempBa.contains(rxHA)) {
+        tempBa.replace(rxHA, "\\1H\\2");
+        ba = tempBa.toLocal8Bit();
+    }
+    // =====================================================================
 
     ba2msg(ba,message);
     int ichk=0;
@@ -9937,9 +10017,27 @@ void MainWindow::genStdMsgs(QString rpt, bool unconditional)
     }
   }
 
-  if (is77BitMode ()) return;
+if (is77BitMode ()) {
+      // HACK: Regex alapú tisztítás a UI számára (HA -> H)
+      auto cleanup = [](QLineEdit* le) {
+          if (le) {
+              // A regex dinamikusan keresi a minta: szám + HA + szám
+              // A \\1 és \\2 megtartja a számokat, de az 'A' betű eltűnik
+              QRegularExpression rx("(\\d+)HA(\\d+)", QRegularExpression::CaseInsensitiveOption);
+              le->setText(le->text().replace(rx, "\\1H\\2"));
+          }
+      };
+      
+      cleanup(ui->tx1);
+      cleanup(ui->tx2);
+      cleanup(ui->tx3);
+      cleanup(ui->tx4);
+      cleanup(ui->tx5->lineEdit());
+      cleanup(ui->tx6);
+  }
 
   if (is_compound) {
+      // ... itt folytatódik az eredeti kód ...
     if (is_type_one) {
       t=hisBase + " " + my_callsign;
       msgtype(t, ui->tx1);
@@ -10011,10 +10109,32 @@ void MainWindow::genStdMsgs(QString rpt, bool unconditional)
       }
     }
   }
-  m_rpt=rpt;
-  if(SpecOp::HOUND == m_specOp and is_compound) ui->tx1->setText("DE " + my_callsign);
-}
+  
+    // A kifestő (TX oldal) - UI-szintű "A" betű visszahelyezés
+    // Ezzel a megoldással nem kell külön írni a tx6-hoz, a lambda megold mindent.
+    auto add_A_letter = [](QLineEdit* le) {
+        if (le) {
+            QString txt = le->text();
+            // A regex: ^(\d{1,3})H(\d{1,4})$ 
+            // Megkeresi a "szám-H-szám" formátumot és "szám-HA-szám"-ra cseréli
+            QRegularExpression rxH(R"(^(\d{1,3})H(\d{1,4})$)", QRegularExpression::CaseInsensitiveOption);
+            if (txt.contains(rxH)) {
+                le->setText(txt.replace(rxH, "\\1HA\\2"));
+            }
+        }
+    };
 
+    // A frissítés az összes mezőn
+    add_A_letter(ui->tx1);
+    add_A_letter(ui->tx2);
+    add_A_letter(ui->tx3);
+    add_A_letter(ui->tx4);
+    add_A_letter(ui->tx5->lineEdit());
+    add_A_letter(ui->tx6); 
+
+    m_rpt=rpt;
+    if(SpecOp::HOUND == m_specOp and is_compound) ui->tx1->setText("DE " + my_callsign);
+} // <--- Itt ér véget a genStdMsgs függvény
 void MainWindow::TxAgain()
 {
   auto_tx_mode(true);

--- a/widgets/mainwindow.h
+++ b/widgets/mainwindow.h
@@ -152,6 +152,7 @@ private:
   void childEvent(QChildEvent *) override;
   bool eventFilter(QObject *, QEvent *) override;
   void showQSYMessage(QString message);
+  QString applyTruncation(QString callsign);
 
 private slots:
   void initialize_fonts ();


### PR DESCRIPTION
Hi Lorenzo, Pietro

First of all, thank you for your incredible work on this fork. Over the past few Ieks, I have been heavily testing the software on the 11m band and encountered some progression issues with the AutoSeq state machine.

After deep-diving into the code, I realized I cannot fool the math of the FT8 77-bit payload. Standard 11m CB callsigns (e.g., 109HA2247) are too long and fall back to Free Text mode, which is strictly limited to 13 characters. To make a QSO fit, the over-the-air callsign must be truncated to drop the second letter of the club prefix (e.g., 109HA2247 -> 109H2247 — consisting of a 1-3 digit country code, 1 letter, and up to a 4-digit unit).

While this truncation works for the RF payload, it breaks the auto_sequence state machine on the receiving end. The WSJT-X engine fails to string-match the truncated callsign against the full callsign in the UI (dxCallEntry), causing AutoSeq to hang at the Tx1/Tx2 phase. Furthermore, 2-word Free Text reports (e.g., 109H2247 +10) are often ignored by the standard parser because it expects >3 words.

What this PR solves:
This pull request introduces a dynamic normalization and state-machine intervention to seamlessly handle these truncated CB callsigns without hardcoded guessing.

Key Changes:

    Dynamic RX Reconstruction (auto_sequence & readFromStdout): Added a Regex-based lambda function (shortenCBCall) that calculates the over-the-air "short" footprint of both m_baseCall and the dxCallEntry target. When parsing message_words, if it detects the truncated version, it dynamically maps and reinjects the full 2-letter club callsign back into the memory before the standard WSJT-X parser evaluates it.

    2-Word Free Text State Machine Hack:
    Implemented a custom parser at the beginning of auto_sequence. If it detects a 2-word targeted message containing a report (e.g., +10 or R-05), it explicitly forces the state machine (m_QSOProgress) to REPORT or ROGER_REPORT and triggers the correct setTxMsg(). This prevents the QSO from hanging.

    Regex Updates in Radio.cpp:
    Adjusted the cb_callsign_multi_digit_suffix_re to correctly allow up to 4-digit suffixes for standard CB callsigns.

    TX / UI Normalization (guiUpdate & genStdMsgs):
    Intercepts the outgoing byte array to truncate the callsign for the airwaves, while keeping the UI clean for the user. (Note: The RX engine is fully universal for any 2-letter club like LR, AT, SD, etc. The TX/UI codebase currently uses a hardcoded HA -> H fallback as a Proof of Concept, which can be easily adapted to the same universal lambda used in RX).

    Minor Transceiver Fixes: Included a few minor stability improvements in HamlibTransceiver (PTT handling) and PollingTransceiver.

We successfully tested this across multiple machines and it provides a 100% fluid AutoSeq experience for 11m DXing. Please review the changes; I hope you find this logic useful for the master branch.

Best regards, Varga Tamas 